### PR TITLE
Run the build at 3am each day

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,7 +10,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
 
 jobs:
   build-image:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,6 +4,9 @@ env:
   ECR_REPOSITORY: saleor-dashboard
 
 on:
+  schedule:
+    # Run every day at 3am
+    - cron: "0 3 * * *"
   push:
     branches:
       - main
@@ -11,7 +14,7 @@ on:
 
 jobs:
   build-image:
-    strategy: 
+    strategy:
       matrix:
         saleor_version: ["3.0", "3.1"]
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will typically be a no-op, but it will pull in changes to the heads of the branches of saleor-dashboard that we care about, so our images are always running the latest release patch.